### PR TITLE
corrects payout for 2H

### DIFF
--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -776,7 +776,7 @@ module Engine
 
         def revenue_for(route, stops)
           additional_revenue = 0
-          if second_edition? && (route.train.name == 'D' || route.train.name == '2H')
+          if second_edition? && (route.train.name == 'D')
             additional_revenue = 30 * (stops.map(&:hex) & route.corporation.tokens.select(&:used).map(&:hex)).size
           end
 


### PR DESCRIPTION
fix for bug #7275
2H trains do not get the $30 token bonus that diesels do.