### PR TITLE
Change track to semi-restrictive

### DIFF
--- a/lib/engine/game/g_1836_jr56/game.rb
+++ b/lib/engine/game/g_1836_jr56/game.rb
@@ -460,7 +460,6 @@ module Engine
         LAYOUT = :pointy
 
         SELL_BUY_ORDER = :sell_buy_sell
-        TRACK_RESTRICTION = :permissive
         TILE_RESERVATION_BLOCKS_OTHERS = true
         def national
           @national ||= corporation_by_id('MESS')


### PR DESCRIPTION
Rules indicate that this game uses 1856 rules except where a difference is indicated. 56 uses semi-restrictive, and nothing in this game's rules says otherwise. 

https://boardgamegeek.com/filepage/114573/1836jr-56-rules