### PR TITLE
[1880 Romania] PR3 mechanics

### DIFF
--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -340,7 +340,7 @@ module Engine
         end
 
         def event_signal_end_game!
-          @log << "-- Event: #{EVENTS_TEXT['signal_end_game'][1]} --"
+          @log << "-- Event: #{self.class::EVENTS_TEXT['signal_end_game'][1]} --"
           @end_game_triggered = true
           @final_operating_rounds = @round.round_num + 3
           game_end_check
@@ -779,7 +779,7 @@ module Engine
         end
 
         def trains_not_triggering_sr?(train_name)
-          TRAINS_NOT_TRIGGERING_SR.include?(train_name)
+          self.class::TRAINS_NOT_TRIGGERING_SR.include?(train_name)
         end
 
         def forced_exchange_rocket?

--- a/lib/engine/game/g_1880_romania/corporation.rb
+++ b/lib/engine/game/g_1880_romania/corporation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../g_1880/corporation'
+
+module Engine
+  module Game
+    module G1880Romania
+      class Corporation < G1880::Corporation
+        def all_abilities
+          all_abilities = @companies.flat_map(&:all_abilities) + @abilities
+          if owner.respond_to?(:companies)
+            all_abilities += owner.companies&.flat_map do |c|
+              next [] unless assigned?(c.id)
+
+              c.all_abilities.select { |a| a.when.to_s.include?('owning_player') }
+            end
+          end
+          all_abilities
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -163,7 +163,7 @@ module Engine
                   { name: '2P', distance: 2, price: 250, num: 10, available_on: 'C2' }].freeze
 
         EVENTS_TEXT = G1880::Game::EVENTS_TEXT.merge(
-          'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase of last 6E train']
+          'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase or export of last 6E train']
         ).freeze
 
         def init_minors
@@ -352,6 +352,13 @@ module Engine
 
         def rocket
           @rocket ||= company_by_id('P7')
+        end
+
+        def event_signal_end_game!
+          @log << "-- Event: #{self.class::EVENTS_TEXT['signal_end_game'][1]} --"
+          @end_game_triggered = true
+          @final_operating_rounds = @round.round_num + 3
+          game_end_check
         end
 
         def event_communist_takeover!

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -175,6 +175,10 @@ module Engine
           super
         end
 
+        def new_draft_round
+          Engine::Round::Draft.new(self, [G1880Romania::Step::SimpleDraft], reverse_order: false)
+        end
+
         def stock_round
           G1880Romania::Round::Stock.new(self, [
             Engine::Step::Exchange,

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -33,6 +33,7 @@ module Engine
           'P4' => '/icons/1880_romania/danube_bonus.svg'
         ).freeze
 
+
         PHASES = [{ name: 'A1', train_limit: 4, tiles: [:yellow] },
                   {
                     name: 'A2',
@@ -323,6 +324,10 @@ module Engine
           return %w[ABC] if corporation == tr
 
           super
+        end
+
+        def trains_not_triggering_sr?(train_name)
+          self.class::TRAINS_NOT_TRIGGERING_SR.include?(train_name)
         end
 
         # hijacks most code from 1880 China referring to BCR to instead refer to the TR

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -6,10 +6,6 @@ require_relative 'map'
 require_relative 'entities'
 require_relative 'corporation'
 require_relative 'minor'
-require_relative 'step/route'
-require_relative 'step/special_choose'
-require_relative 'step/buy_sell_par_shares'
-require_relative 'step/company_pending_par'
 
 module Engine
   module Game
@@ -164,7 +160,7 @@ module Engine
                   { name: '2P', distance: 2, price: 250, num: 10, available_on: 'C2' }].freeze
 
         EVENTS_TEXT = G1880::Game::EVENTS_TEXT.merge(
-          'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase or export of last 6E train']
+          'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase/export of last 6E train']
         ).freeze
 
         def init_minors
@@ -172,7 +168,7 @@ module Engine
         end
 
         def upgrades_to_correct_label?(from, to)
-          # B-labeled tiles are only for Bucuresti (I17), which starts with label=B
+          # B-labeled tiles are only for Bucuresti (I17)
           return false if to.label.to_s == 'B' && from.label.to_s != 'B'
 
           super
@@ -326,11 +322,6 @@ module Engine
           super
         end
 
-        def trains_not_triggering_sr?(train_name)
-          self.class::TRAINS_NOT_TRIGGERING_SR.include?(train_name)
-        end
-
-        # hijacks most code from 1880 China referring to BCR to instead refer to the TR
         def tr
           @tr ||= corporation_by_id('TR')
         end
@@ -357,13 +348,6 @@ module Engine
 
         def rocket
           @rocket ||= company_by_id('P7')
-        end
-
-        def event_signal_end_game!
-          @log << "-- Event: #{self.class::EVENTS_TEXT['signal_end_game'][1]} --"
-          @end_game_triggered = true
-          @final_operating_rounds = @round.round_num + 3
-          game_end_check
         end
 
         def event_communist_takeover!

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -233,7 +233,11 @@ module Engine
         def tile_lays(entity)
           return [] unless can_build_track?(entity)
 
-          self.class::TILE_LAYS
+          tile_lays = [{ lay: true, upgrade: true }]
+          return tile_lays if entity.minor? || !@phase.tiles.include?(:green)
+
+          tile_lays << { lay: :not_if_upgraded, upgrade: false }
+          tile_lays
         end
 
         def remove_crossed_impassable_borders!(tile)

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -4,6 +4,7 @@ require_relative 'meta'
 require_relative '../g_1880/game'
 require_relative 'map'
 require_relative 'entities'
+require_relative 'corporation'
 require_relative 'minor'
 require_relative 'step/route'
 require_relative 'step/special_choose'
@@ -15,6 +16,8 @@ module Engine
         include_meta(G1880Romania::Meta)
         include G1880Romania::Map
         include G1880Romania::Entities
+
+        CORPORATION_CLASS = G1880Romania::Corporation
 
         CURRENCY_FORMAT_STR = 'L%s'
 

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -4,6 +4,7 @@ require_relative 'meta'
 require_relative '../g_1880/game'
 require_relative 'map'
 require_relative 'entities'
+require_relative 'minor'
 require_relative 'step/route'
 require_relative 'step/special_choose'
 
@@ -159,6 +160,10 @@ module Engine
         EVENTS_TEXT = G1880::Game::EVENTS_TEXT.merge(
           'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase of last 6E train']
         ).freeze
+
+        def init_minors
+          game_minors.map { |minor| G1880Romania::Minor.new(**minor) }
+        end
 
         def stock_round
           G1880Romania::Round::Stock.new(self, [

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -297,6 +297,11 @@ module Engine
           str
         end
 
+        # hijacks most code from 1880 China referring to BCR to instead refer to the TR
+        def bcr
+          @bcr ||= corporation_by_id('TR')
+        end
+
         def banater
           @banater ||= company_by_id('P1')
         end

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -230,6 +230,12 @@ module Engine
           @log << "#{consortiu.owner.name} receives #{format_currency(20)} for border crossing"
         end
 
+        def tile_lays(entity)
+          return [] unless can_build_track?(entity)
+
+          self.class::TILE_LAYS
+        end
+
         def remove_crossed_impassable_borders!(tile)
           hex = tile.hex
           removed = false
@@ -261,6 +267,13 @@ module Engine
           end
 
           clear_graph if removed
+        end
+
+        def routes_revenue(routes)
+          # Override to exclude stock_market_bonus from routes_revenue so the autorouter
+          # can compare route combinations fairly. The bonus is added in extra_revenue
+          # via the route step.
+          routes.sum(&:revenue)
         end
 
         def revenue_for(route, stops)

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -262,7 +262,7 @@ module Engine
 
         def revenue_for(route, stops)
           revenue = super
-          revenue += 10 if danube_port_bonus?(route)
+          revenue += 10 if danube_port_bonus?(route, stops)
 
           revenue
         end
@@ -305,8 +305,8 @@ module Engine
           remar.close!
         end
 
-        def danube_port_bonus?(route)
-          route.stops.any? { |stop| stop.hex.assigned?(danube_port.id) } && route.corporation.owner == danube_port.owner
+        def danube_port_bonus?(route, stops = route.stops)
+          stops.any? { |stop| stop.hex.assigned?(danube_port.id) } && route.corporation.owner == danube_port.owner
         end
 
         # This game's Electroputere S.A. private company's forced train exchange is identical to the forced exchange for the

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -232,8 +232,21 @@ module Engine
             hex = hex_by_id(coord)
             next unless hex
 
-            hex.tile.modify_borders(edges, type: nil)
+            edges.each do |edge|
+              border = hex.tile.borders.find { |b| b.edge == edge }
+              next unless border
+
+              hex.tile.borders.delete(border)
+
+              neighbor_hex = hex.all_neighbors[edge]
+              next unless neighbor_hex
+
+              inv_edge = Hex.invert(edge)
+              neighbor_hex.tile.borders.map! { |nb| nb.edge == inv_edge ? nil : nb }.compact!
+            end
           end
+
+          clear_graph
         end
 
         def handle_border_crossing_income

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -165,6 +165,13 @@ module Engine
           game_minors.map { |minor| G1880Romania::Minor.new(**minor) }
         end
 
+        def upgrades_to_correct_label?(from, to)
+          # B-labeled tiles are only for Bucuresti (I17), which starts with label=B
+          return false if to.label.to_s == 'B' && from.label.to_s != 'B'
+
+          super
+        end
+
         def stock_round
           G1880Romania::Round::Stock.new(self, [
             Engine::Step::Exchange,

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -29,7 +29,6 @@ module Engine
           'P4' => '/icons/1880_romania/danube_bonus.svg'
         ).freeze
 
-
         PHASES = [{ name: 'A1', train_limit: 4, tiles: [:yellow] },
                   {
                     name: 'A2',

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -8,6 +8,8 @@ require_relative 'corporation'
 require_relative 'minor'
 require_relative 'step/route'
 require_relative 'step/special_choose'
+require_relative 'step/buy_sell_par_shares'
+require_relative 'step/company_pending_par'
 
 module Engine
   module Game
@@ -179,11 +181,18 @@ module Engine
           Engine::Round::Draft.new(self, [G1880Romania::Step::SimpleDraft], reverse_order: false)
         end
 
+        def new_auction_round
+          Engine::Round::Auction.new(self, [
+            G1880Romania::Step::CompanyPendingPar,
+            G1880::Step::SelectionAuction,
+          ])
+        end
+
         def stock_round
           G1880Romania::Round::Stock.new(self, [
             Engine::Step::Exchange,
             G1880Romania::Step::SpecialChoose,
-            G1880::Step::BuySellParShares,
+            G1880Romania::Step::BuySellParShares,
           ])
         end
 
@@ -298,8 +307,8 @@ module Engine
         end
 
         # hijacks most code from 1880 China referring to BCR to instead refer to the TR
-        def bcr
-          @bcr ||= corporation_by_id('TR')
+        def tr
+          @tr ||= corporation_by_id('TR')
         end
 
         def banater

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -306,6 +306,12 @@ module Engine
           str
         end
 
+        def building_permit_choices(corporation)
+          return %w[ABC] if corporation == tr
+
+          super
+        end
+
         # hijacks most code from 1880 China referring to BCR to instead refer to the TR
         def tr
           @tr ||= corporation_by_id('TR')

--- a/lib/engine/game/g_1880_romania/minor.rb
+++ b/lib/engine/game/g_1880_romania/minor.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../g_1880/minor'
+
+module Engine
+  module Game
+    module G1880Romania
+      class Minor < G1880::Minor
+        def all_abilities
+          @abilities
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1880_romania/step/buy_sell_par_shares.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1880/step/buy_sell_par_shares'
+require_relative 'parrer'
+
+module Engine
+  module Game
+    module G1880Romania
+      module Step
+        class BuySellParShares < G1880::Step::BuySellParShares
+          include Parrer
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania/step/company_pending_par.rb
+++ b/lib/engine/game/g_1880_romania/step/company_pending_par.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1880/step/company_pending_par'
+require_relative 'parrer'
+
+module Engine
+  module Game
+    module G1880Romania
+      module Step
+        class CompanyPendingPar < G1880::Step::CompanyPendingPar
+          include Parrer
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania/step/parrer.rb
+++ b/lib/engine/game/g_1880_romania/step/parrer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1880Romania
+      module Step
+        module Parrer
+          def president_percent_choices
+            max_shares = (@parring[:entity].cash.to_f / @parring[:share_price].price).floor
+            max_percent = @parring[:corporation] == @game.tr ? 20 : max_shares * @parring[:corporation].share_percent
+            { 20 => '20%', 30 => '30%', 40 => '40%' }.select { |k, _v| k <= max_percent }
+          end
+
+          def get_par_prices(entity, _corp)
+            @game.stock_market.par_prices
+              .select { |p| p.price * 2 <= entity.cash }
+              .select { |p| @game.par_chart[p].include?(nil) }
+          end
+
+          def setup_par_choices(action)
+            share_price = action.share_price
+            slot = action.slot
+            entity = action.entity
+            corp = action.corporation
+
+            unless @game.loading
+              raise GameError, 'Par slot already taken' if @game.par_chart[share_price][slot]
+
+              unless get_par_prices(entity, corp).include?(share_price)
+                raise GameError, "#{entity.name} does not have enough cash (#{@game.format_currency(entity.cash)} to par at" \
+                                 "#{format_currency(share_price.price)}"
+              end
+            end
+
+            @game.set_par(corp, share_price, slot)
+            @log << "#{entity.name} selects par #{@game.format_currency(share_price.price)} (slot #{slot}) for #{corp.name}"
+
+            @parring = {
+              state: :choose_percent,
+              corporation: corp,
+              share_price: share_price,
+              entity: entity,
+            }
+            percent_choices = president_percent_choices
+            return if percent_choices.size > 1
+
+            process_presidents_percent_choice(Action::Choose.new(@parring[:entity], choice: percent_choices.keys.first))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania/step/parrer.rb
+++ b/lib/engine/game/g_1880_romania/step/parrer.rb
@@ -33,7 +33,7 @@ module Engine
             end
 
             @game.set_par(corp, share_price, slot)
-            @log << "#{entity.name} selects par #{@game.format_currency(share_price.price)} (slot #{slot}) for #{corp.name}"
+            @log << "#{entity.name} selects par #{@game.format_currency(share_price.price)} (slot #{slot + 1}) for #{corp.name}"
 
             @parring = {
               state: :choose_percent,
@@ -45,6 +45,53 @@ module Engine
             return if percent_choices.size > 1
 
             process_presidents_percent_choice(Action::Choose.new(@parring[:entity], choice: percent_choices.keys.first))
+          end
+
+          def process_presidents_percent_choice(action)
+            percent = action.choice
+            unless president_percent_choices.include?(percent)
+              error_msg = "Invalid percentage (#{percent}). " \
+                          "Choices are #{president_percent_choices.values.join(',')}."
+              raise GameError, error_msg
+            end
+
+            corporation = @parring[:corporation]
+            verb = corporation == @game.tr ? 'receives' : 'selects'
+            @log << "#{@parring[:entity].name} #{verb} #{percent}% presidency share"
+
+            if percent != corporation.presidents_percent
+              num_to_remove = (percent - corporation.presidents_percent) / corporation.share_percent
+              shares_to_remove = corporation.shares.select { |s| s.buyable && !s.president }.pop(num_to_remove)
+              shares_to_remove.each { |s| corporation.delete_share!(s) }
+              corporation.presidents_share.percent = percent
+            end
+
+            @parring[:state] = :choose_permit
+            permit_choices = @game.building_permit_choices(corporation)
+            return if permit_choices.size > 1
+
+            process_building_permit_choice(Action::Choose.new(@parring[:entity], choice: permit_choices.first))
+          end
+
+          def process_building_permit_choice(action)
+            permit = action.choice
+            unless @game.building_permit_choices(@parring[:corporation]).include?(permit)
+              error_msg = "Invalid building permit (#{permit}). " \
+                          "Choices are #{@game.building_permit_choices(@parring[:corporation]).join(',')}."
+              raise GameError, error_msg
+            end
+
+            @log << if @parring[:corporation] == @game.tr
+                      "#{@parring[:corporation].name} is automatically assigned an #{permit} building permit"
+                    else
+                      "#{@parring[:entity].name} selects #{permit} building permit"
+                    end
+
+            @parring[:corporation].building_permits = action.choice
+
+            @parring[:state] = :par_corporation
+            process_par(Action::Par.new(@parring[:entity], corporation: @parring[:corporation],
+                                                           share_price: @parring[:share_price]))
           end
         end
       end

--- a/lib/engine/game/g_1880_romania/step/route.rb
+++ b/lib/engine/game/g_1880_romania/step/route.rb
@@ -79,6 +79,7 @@ module Engine
             end
 
             @tender_train.name = tender_name(@tender_train.name)
+            @game.clear_graph
           end
 
           def detach_tender
@@ -86,6 +87,7 @@ module Engine
             @tender_train.distance = @tender_original_train.distance
             @tender_original_train = nil
             @tender_train = nil
+            @game.clear_graph
           end
 
           def tender_name(name)

--- a/lib/engine/game/g_1880_romania/step/route.rb
+++ b/lib/engine/game/g_1880_romania/step/route.rb
@@ -41,6 +41,12 @@ module Engine
           def process_run_routes(action)
             super
             detach_tender if @tender_train
+
+            bonus = @game.stock_market_bonus(action.entity)
+            return unless bonus.positive?
+
+            @round.extra_revenue = (@round.extra_revenue || 0) + bonus
+            @log << "#{action.entity.name} receives #{@game.format_currency(bonus)} stock market bonus"
           end
 
           private

--- a/lib/engine/game/g_1880_romania/step/simple_draft.rb
+++ b/lib/engine/game/g_1880_romania/step/simple_draft.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1880/step/simple_draft'
+
+module Engine
+  module Game
+    module G1880Romania
+      module Step
+        class SimpleDraft < G1880::Step::SimpleDraft
+          attr_reader :minors
+
+          def process_bid(action)
+            minor = action.minor
+            player = action.entity
+
+            minor.owner = player
+            minor.float!
+
+            @minors.delete(minor)
+
+            @log << "#{player.name} chooses #{minor.full_name} (#{minor.name})"
+
+            # this line hijacks the BCR share assignment from 1880 China to assign to the TR instead
+            assign_bcr_share_to_fi(action.entity, minor) if player.shares.find { |s| s.corporation.id == 'TR' }
+
+            @round.next_entity_index!
+            action_finalized
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

  Implements core game mechanics for 1880 Romania:

  - Restrict B-labeled tile to Bucuresti hex
  - Fix routing for + trains
  - Mask company abilities on corps unless assigned
  - Tile lay rules (1 lay, 2 as of green phase)
  - Fix FI assignment for TR corp
  - TR hijacks BCR role from 1880 China; receives ABC building permit automatically
  - Province border income and border removal at communism phase
  - Signal end game event text
  - Prevent last 8 train from triggering SR

  Depends on #12502 (PR1) and #12503 (PR2).

### Screenshots

### Any Assumptions / Hacks
